### PR TITLE
Fix player leaving

### DIFF
--- a/server/modules/cards/drawCards.ts
+++ b/server/modules/cards/drawCards.ts
@@ -34,7 +34,8 @@ export const replenishWhiteCards = (
 ) => {
     for (let i = 0, limit = game.players.length; i < limit; i++) {
         const player = game.players[i];
-        if (!["active", "playing", "waiting"].includes(player.state)) continue;
+        if (!["active", "playing", "waiting", "joining"].includes(player.state))
+            continue;
 
         const missingCards =
             gameOptions.startingWhiteCardCount - player.whiteCards.length;

--- a/server/modules/connections/disconnect.ts
+++ b/server/modules/connections/disconnect.ts
@@ -59,10 +59,20 @@ export const setPlayerDisconnected = async (
     }
 
     if (shouldRemove || player.state === "spectating") {
-        player.state = "leaving";
         player.sockets.map((socket) => closeSocketWithID(io, socket));
-        player.sockets = [];
-        game.players = setPlayer(game.players, player);
+
+        if (
+            game.stateMachine.state === "lobby" ||
+            game.stateMachine.state === "gameOver"
+        ) {
+            game.players = game.players.filter(
+                (gamePlayer) => gamePlayer.id !== player.id
+            );
+        } else {
+            player.state = "leaving";
+            player.sockets = [];
+            game.players = setPlayer(game.players, player);
+        }
     } else {
         player.state = "disconnected";
         player.sockets = remainingSockets;

--- a/server/modules/connections/disconnect.ts
+++ b/server/modules/connections/disconnect.ts
@@ -59,12 +59,10 @@ export const setPlayerDisconnected = async (
     }
 
     if (shouldRemove || player.state === "spectating") {
-        game.players = game.players.filter(
-            (gamePlayer: CAH.Player) => gamePlayer.id !== player.id
-        );
-        player.sockets.map((socket: string) => {
-            closeSocketWithID(io, socket);
-        });
+        player.state = "leaving";
+        player.sockets.map((socket) => closeSocketWithID(io, socket));
+        player.sockets = [];
+        game.players = setPlayer(game.players, player);
     } else {
         player.state = "disconnected";
         player.sockets = remainingSockets;

--- a/server/modules/games/gameUtil.ts
+++ b/server/modules/games/gameUtil.ts
@@ -142,7 +142,7 @@ export const findGameByPlayerID = async (
 export const shouldGameBeDeleted = (game: CAH.Game) => {
     if (game.stateMachine.state === "lobby") {
         return game.players.every((player) =>
-            ["disconnected", "spectating"].includes(player.state)
+            ["disconnected", "leaving", "spectating"].includes(player.state)
         );
     } else {
         return false;

--- a/server/modules/players/playerUtil.ts
+++ b/server/modules/players/playerUtil.ts
@@ -107,7 +107,10 @@ export const getAllActivePlayers = (players: CAH.Player[]) =>
     );
 
 export const getAllButDisconnectedPlayers = (players: CAH.Player[]) =>
-    players.filter((player) => player.state !== "disconnected");
+    players.filter(
+        (player) =>
+            player.state !== "disconnected" && player.state !== "leaving"
+    );
 
 export const getPlayerByWhiteCards = (
     game: CAH.Game,
@@ -115,7 +118,7 @@ export const getPlayerByWhiteCards = (
 ) => {
     if (!game.currentRound) return undefined;
 
-    const players = game.currentRound.whiteCardsByPlayer.filter(
+    const player = game.currentRound.whiteCardsByPlayer.find(
         (whiteCardByPlayer) => {
             if (whiteCardIDs.length !== whiteCardByPlayer.whiteCards.length)
                 return false;
@@ -129,5 +132,5 @@ export const getPlayerByWhiteCards = (
 
     // There should always be exactly one player
     // No more, no less
-    return players.length === 1 ? players[0].playerID : undefined;
+    return player?.playerID;
 };

--- a/server/modules/players/playerUtil.ts
+++ b/server/modules/players/playerUtil.ts
@@ -130,7 +130,5 @@ export const getPlayerByWhiteCards = (
         }
     );
 
-    // There should always be exactly one player
-    // No more, no less
     return player?.playerID;
 };

--- a/server/modules/players/resetPlayer.ts
+++ b/server/modules/players/resetPlayer.ts
@@ -11,7 +11,10 @@ const resetPlayerState = (player: CAH.Player) => {
 };
 
 export const resetPlayers = (players: CAH.Player[]): CAH.Player[] => {
-    return players.map((player) => ({
+    const filteredPlayers = players.filter(
+        (player) => player.state !== "leaving"
+    );
+    return filteredPlayers.map((player) => ({
         ...player,
         score: 0,
         state: resetPlayerState(player),

--- a/server/modules/rounds/skipRound.ts
+++ b/server/modules/rounds/skipRound.ts
@@ -13,6 +13,7 @@ import { appointNextCardCzar } from "../players/cardCzar";
 import { changeGameStateAfterTime } from "../utilities/delayedStateChange";
 import { endGame } from "../games/endGame";
 import { gameOptions } from "../../consts/gameSettings";
+import { removeLeavingPlayers } from "./startRound";
 import { returnToLobby } from "./returnToLobby";
 import { setGame } from "../games/gameUtil";
 import { setPlayersWaiting } from "../players/setPlayers";
@@ -36,6 +37,7 @@ export const skipRound = async (
     newGame.stateMachine.skipRound();
     newGame.client.state = newGame.stateMachine.state;
 
+    newGame.players = removeLeavingPlayers(io, newGame.players);
     newGame.players = setPlayersWaiting(newGame.players);
 
     const newerGame = dealBlackCards(io, newCardCzar.sockets, newGame);

--- a/server/modules/rounds/skipRound.ts
+++ b/server/modules/rounds/skipRound.ts
@@ -13,6 +13,7 @@ import { appointNextCardCzar } from "../players/cardCzar";
 import { changeGameStateAfterTime } from "../utilities/delayedStateChange";
 import { endGame } from "../games/endGame";
 import { gameOptions } from "../../consts/gameSettings";
+import { returnToLobby } from "./returnToLobby";
 import { setGame } from "../games/gameUtil";
 import { setPlayersWaiting } from "../players/setPlayers";
 import { shuffleCardsBackToDeck } from "../cards/shuffleCards";
@@ -83,5 +84,9 @@ export const restartRound = async (
     game.players = appointNextCardCzar(game, cardCzar.id);
     const nextCardCzar = getCardCzar(game.players);
 
-    await skipRound(io, game, nextCardCzar!, client);
+    if (!nextCardCzar) {
+        returnToLobby(io, game, client);
+        return;
+    }
+    await skipRound(io, game, nextCardCzar, client);
 };

--- a/server/modules/rounds/startRound.ts
+++ b/server/modules/rounds/startRound.ts
@@ -3,6 +3,7 @@ import * as SocketIO from "socket.io";
 import * as pg from "pg";
 
 import { ERROR_TYPES, NOTIFICATION_TYPES } from "../../consts/error";
+import { closeSocketWithID, sendNotification } from "../utilities/socket";
 import { dealBlackCards, replenishWhiteCards } from "../cards/drawCards";
 import { getGame, setGame } from "../games/gameUtil";
 import { validateCardCzar, validateGameEnding } from "../utilities/validate";
@@ -11,7 +12,6 @@ import { appointNextCardCzar } from "../players/cardCzar";
 import { changeGameStateAfterTime } from "../utilities/delayedStateChange";
 import { endGame } from "../games/endGame";
 import { getRoundWinner } from "../players/playerUtil";
-import { sendNotification } from "../utilities/socket";
 import { setPlayersWaiting } from "../players/setPlayers";
 import { setPopularVoteLeader } from "../cards/popularVote";
 import { updatePlayersIndividually } from "../players/emitPlayers";
@@ -36,6 +36,8 @@ export const startNewRound = async (
         }
         return;
     }
+
+    game.players = removeLeavingPlayers(io, game.players);
 
     if (validateGameEnding(game)) {
         await endGame(io, game, client);
@@ -76,4 +78,16 @@ export const startNewRound = async (
     game = changeGameStateAfterTime(io, game, "startPlayingWhiteCards");
     await setGame(game, client);
     updatePlayersIndividually(io, game);
+};
+
+const removeLeavingPlayers = (io: SocketIO.Server, players: CAH.Player[]) => {
+    return players.filter((player) => {
+        if (player.state === "leaving") {
+            player.sockets.map((socket: string) => {
+                closeSocketWithID(io, socket);
+            });
+            return false;
+        }
+        return true;
+    });
 };

--- a/server/modules/rounds/startRound.ts
+++ b/server/modules/rounds/startRound.ts
@@ -80,7 +80,10 @@ export const startNewRound = async (
     updatePlayersIndividually(io, game);
 };
 
-const removeLeavingPlayers = (io: SocketIO.Server, players: CAH.Player[]) => {
+export const removeLeavingPlayers = (
+    io: SocketIO.Server,
+    players: CAH.Player[]
+) => {
     return players.filter((player) => {
         if (player.state === "leaving") {
             player.sockets.map((socket: string) => {

--- a/server/modules/utilities/anonymize.ts
+++ b/server/modules/utilities/anonymize.ts
@@ -53,7 +53,10 @@ export const publicPlayersObject = (
     players: CAH.Player[],
     playerID: string
 ) => {
-    return players?.map((player) => {
+    var filteredPlayers = players.filter(
+        (player) => player.state !== "leaving"
+    );
+    return filteredPlayers?.map((player) => {
         const { id, sockets, whiteCards, popularVoteScore, ...rest } = player;
         if (player.id === playerID) {
             return { id: playerID, ...rest };

--- a/server/types/types.ts
+++ b/server/types/types.ts
@@ -226,7 +226,8 @@ export type PlayerState =
     | "joining"
     | "pickingName"
     | "disconnected"
-    | "spectating";
+    | "spectating"
+    | "leaving";
 
 export type NotificationType = "default" | "error" | "success";
 export type NotificationTypes = { [key: string]: NotificationType };


### PR DESCRIPTION
## Changes
- When player leaves, instead of directly removing the player, the player is put in `leaving` state
- This fixes the problem, where card czar picks winner, but that player doesn't exist anymore
- When new round is started, a round is restarted or the game goes to lobby, leaving players are removed completely
- Hopefully this introduces no new bugs 🙃 
- No changes required to frontend, this is purely backend logic
- Also fixes a bug where a player could join without ever getting white cards